### PR TITLE
added missing trainer name/id/sid offsets to Memory Link Editor

### DIFF
--- a/BW_tool/Editors/MemoryLink.cs
+++ b/BW_tool/Editors/MemoryLink.cs
@@ -461,6 +461,7 @@ namespace BW_tool
 		                    .Replace("\u0027", "\u2019") // farfetch'd
 		                    .PadRight(value.Length + 1, (char)0xFFFF); // Null Terminator
 		                Encoding.Unicode.GetBytes(TempNick).CopyTo(Data, 0x48);
+                            	Encoding.Unicode.GetBytes(TempNick).CopyTo(Data, 0x60);
 		                Encoding.Unicode.GetBytes(TempNick).CopyTo(Data, 0x78);
 		            }
 		        }
@@ -473,6 +474,7 @@ namespace BW_tool
 		            set
 		            {
 		            	setData(BitConverter.GetBytes((UInt16)value), 0x44);
+                            	setData(BitConverter.GetBytes((UInt16)value), 0x5C);
 		            	setData(BitConverter.GetBytes((UInt16)value), 0x74);
 		            }
 		        }
@@ -485,6 +487,7 @@ namespace BW_tool
 		            set
 		            {
 		            	setData(BitConverter.GetBytes((UInt16)value), 0x46);
+                            	setData(BitConverter.GetBytes((UInt16)value), 0x5E);
 		            	setData(BitConverter.GetBytes((UInt16)value), 0x76);
 		            }
 		        }


### PR DESCRIPTION
The trainer name from the added offset 0x60 is used when you receive the prop case.